### PR TITLE
Update git source

### DIFF
--- a/sources/git/load_source.go
+++ b/sources/git/load_source.go
@@ -192,7 +192,6 @@ func objectsFromStagedFiles(repo *git.Repository) ([]models.Object, error) {
 
 			o := models.NewObject(entryFile.Path, Type, "file-content", blob.Contents())
 
-			// TODO: Type of staged.
 			o.SetMetadata("status", "staged", models.MetadataAttributes{})
 			objectList = append(objectList, *o)
 		}
@@ -295,7 +294,7 @@ func openGitRepoRemote(gitUri string) (*git.Repository, error) {
 }
 
 func openGitRepoLocal(source string) (*git.Repository, error) {
-	repo, err := git.OpenRepositoryExtended(source, git.RepositoryOpenCrossFs, "")
+	repo, err := git.OpenRepositoryExtended(source, git.RepositoryOpenFromEnv, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR does a couple things:
1. Uses the `StatusList` implementation instead of doing a for loop on every index entry. This solves issues that some folks have been having with large repositories: https://github.com/18F/git-seekret/issues/17
2. Opens the repo with environment intact, so that  it picks up `GIT_INDEX_FILE` during direct git commit without a implicit stage. See more on this here: https://github.com/libgit2/libgit2/issues/4152 and https://github.com/libgit2/git2go/pull/366